### PR TITLE
support usage errors by allowing handlers to return henry.UsageError

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,13 @@
+package henry
+
+import (
+	"fmt"
+)
+
+type UsageError struct {
+	UsageMessage string
+}
+
+func (u UsageError) Error() string {
+	return fmt.Sprintf("Handled illegal user input.  Expected: '%s'", u.UsageMessage)
+}


### PR DESCRIPTION
Handler functions have an "error" that they can return.  If they choose to return a Henry.UsageError, the bot will reply with a usage error.  Else the bot will not say anything.